### PR TITLE
init module, add db and api package structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # retask-auth-api
+
 auth api for the retask-server

--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,3 @@
+# api
+
+This package defines all api functionality in the form of interfaces. packages that implement this api should use the db package in their function signatures when making database calls and use a mocked implementation of db package in tests.

--- a/api/api.go
+++ b/api/api.go
@@ -1,0 +1,1 @@
+package api

--- a/db/README.md
+++ b/db/README.md
@@ -1,0 +1,3 @@
+# db
+
+This package is only responsible for defining database interfaces that the api packages will use in their function signatures. Other packages will be responsible for actually implementing interface defined in this package.

--- a/db/db.go
+++ b/db/db.go
@@ -1,0 +1,1 @@
+package db

--- a/db/mock/README.md
+++ b/db/mock/README.md
@@ -1,0 +1,3 @@
+# mock
+
+This package implements the db package interface with the intent of providing mocking for all api packages.

--- a/db/mock/mock.go
+++ b/db/mock/mock.go
@@ -1,0 +1,1 @@
+package mock

--- a/db/pg/README.md
+++ b/db/pg/README.md
@@ -1,0 +1,3 @@
+# PG
+
+The Postgres driver for the auth api. interfaces will be defined in this modules db package that this package will implement.

--- a/db/pg/pg.go
+++ b/db/pg/pg.go
@@ -1,0 +1,1 @@
+package pg

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/hyqe/retask-auth-api
+
+go 1.15

--- a/main.go
+++ b/main.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+
+}


### PR DESCRIPTION
Defines the basic structure of the module and its packages. The intent is to make it as mockable and decoupled as possible, with a heavy use of interfaces.